### PR TITLE
chore: name go module at public path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aziis98/uploader
+module github.com/aziis98/mup
 
 go 1.23.0
 


### PR DESCRIPTION
Allows a go get to build