### PR TITLE
Removes any temporary files (/tmp/multipart-*) after upload

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,6 +210,7 @@ func main() {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		defer r.MultipartForm.RemoveAll()
 
 		files := r.MultipartForm.File["files"]
 		for _, file := range files {


### PR DESCRIPTION
The  [code at this link](https://github.com/golang/go/blob/master/src/mime/multipart/formdata.go#L177) generates temporary files that are not removed automatically. As a result, the temporary directory inside Docker containers accumulates these files over time. This leads to an increase in the size of overlay2 storage layers due to the accumulation of difference files generated from the undeleted temp files.

This pull request fixes this behavior.